### PR TITLE
fix: release Lucene lock before retry on corrupt index

### DIFF
--- a/docs-core/src/main/java/com/sismics/docs/core/util/indexing/LuceneIndexingHandler.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/util/indexing/LuceneIndexingHandler.java
@@ -105,6 +105,17 @@ public class LuceneIndexingHandler implements IndexingHandler {
         } catch (Exception e) {
             // An error occurred initializing Lucene, the index is out of date or broken, delete everything
             log.info("Unable to initialize Lucene, cleaning up the index: " + e.getMessage());
+
+            // Release the lock before deleting — initLucene may have partially succeeded
+            if (indexWriter != null) {
+                try { indexWriter.close(); } catch (Exception ignored) {}
+                indexWriter = null;
+            }
+            if (directory != null) {
+                try { directory.close(); } catch (Exception ignored) {}
+                directory = null;
+            }
+
             Path luceneDirectory = DirectoryUtil.getLuceneDirectory();
             Files.walk(luceneDirectory)
                     .sorted(Comparator.reverseOrder())


### PR DESCRIPTION
## Summary
- When `initLucene()` fails during `CheckIndex`, the `IndexWriter` already holds `write.lock`
- The catch block deleted index files but never closed the writer/directory
- Retry attempt hit `LockObtainFailedException` from the same JVM
- Fix: close `indexWriter` and `directory` before deleting files and retrying

## Test plan
- [x] Code review — change is isolated to error-recovery path
- [ ] CI passes (no Java 21 locally)
- [ ] Deploy to Saturn and verify no more Lucene lock errors on startup