### PR TITLE
TEST: prove PR-gating CI (DEP-02) — do not merge

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -118,3 +118,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+
+# DEP-02 PR-gating proof: this trivial change exercises the pull_request CI path.


### PR DESCRIPTION
Throwaway PR to verify DEP-02: the pull_request trigger runs test+build and the docker job is skipped (no image pushed). Will be closed without merging.